### PR TITLE
Use replaceAll instead of replace

### DIFF
--- a/libs/loaders/jwt.js
+++ b/libs/loaders/jwt.js
@@ -40,7 +40,7 @@ var Jwt = /*#__PURE__*/function () {
 
     if (this.jwt) {
       var base64Url = this.jwt.split('.')[1];
-      var base64 = base64Url.replaceAll('-', '+').replaceAll('_', '/');
+      var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
 
       try {
         this._decodedJwt = JSON.parse(window.atob(base64));

--- a/libs/loaders/jwt.js
+++ b/libs/loaders/jwt.js
@@ -40,7 +40,7 @@ var Jwt = /*#__PURE__*/function () {
 
     if (this.jwt) {
       var base64Url = this.jwt.split('.')[1];
-      var base64 = base64Url.replace('-', '+').replace('_', '/');
+      var base64 = base64Url.replaceAll('-', '+').replaceAll('_', '/');
 
       try {
         this._decodedJwt = JSON.parse(window.atob(base64));

--- a/src/loaders/jwt.js
+++ b/src/loaders/jwt.js
@@ -18,7 +18,7 @@ export class Jwt {
 
     if (this.jwt) {
       const base64Url = this.jwt.split('.')[1];
-      const base64 = base64Url.replace('-', '+').replace('_', '/');
+      const base64 = base64Url.replaceAll('-', '+').replaceAll('_', '/');
       try {
         this._decodedJwt = JSON.parse(window.atob(base64));
         this.userId = this._decodedJwt.user_id;

--- a/src/loaders/jwt.js
+++ b/src/loaders/jwt.js
@@ -18,7 +18,7 @@ export class Jwt {
 
     if (this.jwt) {
       const base64Url = this.jwt.split('.')[1];
-      const base64 = base64Url.replaceAll('-', '+').replaceAll('_', '/');
+      const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
       try {
         this._decodedJwt = JSON.parse(window.atob(base64));
         this.userId = this._decodedJwt.user_id;


### PR DESCRIPTION
When decoding the jwt, we use `.replace('-', '+')` (and `replace('_', '/')`) which only replaces the _first_ `-`. This can occasionally lead to issues with JWTs that contain more than one `-` not being able to decode properly, it seems unintentional to only be replacing the first one, and other JWT decoding code I've looked at either uses `replaceAll` or `replace(/-/g, '+')` which also avoids the issue of only replacing the first instance.