### PR TITLE
cmr/performance patch 176954128

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ convenience, so you can do this:
 ```Javascript
 import { configureStore } from 'atomic-fuel';
 ```
+
+## Testing
+Run tests:
+`yarn test`
+
+Run tests with Chrome DevTools (i.e. use debugger in your tests):
+1. Open a Chromium browser at `chrome://inspect`
+2. Click on the "Open dedicated DevTools for Node"
+
+Then you can run tests using:
+`yarn test:debug`

--- a/libs/api/api.js
+++ b/libs/api/api.js
@@ -71,10 +71,10 @@ var Api = /*#__PURE__*/function () {
             break;
 
           case _network["default"].DEL:
-            if (body) {
-              request = _superagent["default"].del(fullUrl).send(body);
-            } else {
+            if (_lodash["default"].isEmpty(body)) {
               request = _superagent["default"].del(fullUrl);
+            } else {
+              request = _superagent["default"].del(fullUrl).send(body);
             }
 
             break;

--- a/libs/api/api.spec.js
+++ b/libs/api/api.spec.js
@@ -133,18 +133,6 @@ describe('api', function () {
 
     expect(nockRequest.isDone()).toBeTruthy();
   });
-  it('calls execRequest on a Delete with body', function () {
-    var url = '/api/test/8';
-
-    var nockRequest = _helper["default"].mockRequest('delete', apiUrl, url, expectedHeaders);
-
-    _api["default"].execRequest(_network["default"].DEL, url, apiUrl, null, null).then(function (result) {
-      expect(result.statusCode).toBe(200);
-      expect(result.text).toEqual(_helper["default"].testPayload());
-    });
-
-    expect(nockRequest.isDone()).toBeTruthy();
-  });
   it('calls execRequest with optional timeout', function () {
     var url = '/api/test/7';
     var timeout = 1000;
@@ -152,6 +140,20 @@ describe('api', function () {
     var nockRequest = _helper["default"].mockRequest('get', apiUrl, url, expectedHeaders);
 
     _api["default"].execRequest(_network["default"].GET, url, apiUrl, null, null, {}, {}, {}, timeout).then(function (result) {
+      expect(result.statusCode).toBe(200);
+      expect(result.text).toEqual(_helper["default"].testPayload());
+    });
+
+    expect(nockRequest.isDone()).toBeTruthy();
+  });
+  it('calls execRequest on a Delete with body', function () {
+    var url = '/api/test/8';
+
+    var nockRequest = _helper["default"].mockRequest('delete', apiUrl, url, expectedHeaders);
+
+    _api["default"].execRequest(_network["default"].DEL, url, apiUrl, null, null, {}, {
+      foo: 'bar'
+    }).then(function (result) {
       expect(result.statusCode).toBe(200);
       expect(result.text).toEqual(_helper["default"].testPayload());
     });

--- a/libs/libs/styles.js
+++ b/libs/libs/styles.js
@@ -3,12 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.getAddStyles = getAddStyles;
 exports["default"] = void 0;
 
 function getAddStyles() {
-  var styleEl = document.getElementById(id);
   var memo = {};
   var id = 'atomic-fuel-styles';
+  var styleEl = document.getElementById(id);
   return function (styles) {
     if (!styleEl) {
       styleEl = document.createElement('style');

--- a/libs/libs/styles.js
+++ b/libs/libs/styles.js
@@ -3,10 +3,10 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.getAddStyles = getAddStyles;
 exports["default"] = void 0;
 
 function getAddStyles() {
+  var selectorTextRegex = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : /[^{]*/;
   var memo = {};
   var id = 'atomic-fuel-styles';
   var styleEl = document.getElementById(id);
@@ -16,8 +16,14 @@ function getAddStyles() {
       styleEl.id = id;
       document.head.appendChild(styleEl);
     }
+    /*
+     * The RegEx below extracts the selectorText from the styles
+     * string. For example running this regex on the styles string
+     * ".myClass > h1 .myclassTwo {...}" would yield ".myClass > h1 .myclassTwo"
+     */
 
-    var classes = styles.match(/.*[^{]/)[0];
+
+    var classes = styles.match(selectorTextRegex)[0].trim();
 
     if (memo[classes] === undefined) {
       var styleSheet = styleEl.sheet;

--- a/libs/libs/styles.js
+++ b/libs/libs/styles.js
@@ -3,18 +3,29 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports["default"] = addStyles;
+exports["default"] = void 0;
 
-function addStyles(styles) {
-  var id = 'atomic-fuel-styles';
+function getAddStyles() {
   var styleEl = document.getElementById(id);
+  var memo = {};
+  var id = 'atomic-fuel-styles';
+  return function (styles) {
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = id;
+      document.head.appendChild(styleEl);
+    }
 
-  if (!styleEl) {
-    styleEl = document.createElement('style');
-    styleEl.id = id;
-    document.head.appendChild(styleEl);
-  }
+    var classes = styles.match(/.*[^{]/)[0];
 
-  var styleSheet = styleEl.sheet;
-  styleSheet.insertRule(styles, styleSheet.cssRules.length);
+    if (memo[classes] === undefined) {
+      var styleSheet = styleEl.sheet;
+      styleSheet.insertRule(styles, styleSheet.cssRules.length);
+      memo[classes] = 1;
+    }
+  };
 }
+
+var _default = getAddStyles();
+
+exports["default"] = _default;

--- a/libs/libs/styles.spec.js
+++ b/libs/libs/styles.spec.js
@@ -4,4 +4,33 @@ var _styles = _interopRequireDefault(require("./styles.js"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
-describe('addStyles function', function () {});
+describe('addStyles function', function () {
+  it('Should only add one class rule to the style element when invoked repetitively', function () {
+    for (var i = 0; i < 5; i += 1) {
+      (0, _styles["default"])(".error-banner__content {\n        color: #fff;\n        font-family: 'montserratregular';\n        font-weight: normal;\n        font-size: 1.4rem;\n      }");
+    }
+
+    var styleEl = document.getElementById('atomic-fuel-styles');
+    var stylesheet = styleEl.sheet;
+    var rulesLength = stylesheet.cssRules.length;
+    expect(rulesLength).toEqual(1);
+  });
+  it('Should not insert repetitive selectorText to the style element', function () {
+    var expectedSelectorTextOne = '.error-banner__content';
+    var expectedSelectorTextTwo = '.atomicjolt-loading-animation svg polygon, .atomicjolt-loading-animation svg polyline';
+
+    for (var i = 0; i < 5; i += 1) {
+      (0, _styles["default"])("".concat(expectedSelectorTextOne, " {\n        color: #fff;\n        font-family: 'montserratregular';\n        font-weight: normal;\n        font-size: 1.4rem;\n      }"));
+      (0, _styles["default"])("".concat(expectedSelectorTextTwo, "{\n        fill: none;\n        stroke: #424;\n        stroke-linecap: round;\n        stroke-linejoin: round;\n        stroke-width: 8px;\n      }"));
+    }
+
+    var styleEl = document.getElementById('atomic-fuel-styles');
+    var stylesheet = styleEl.sheet;
+    var rulesLength = stylesheet.cssRules.length;
+    var selectorTextOne = stylesheet.cssRules[0].selectorText;
+    var selectorTextTwo = stylesheet.cssRules[1].selectorText;
+    expect(rulesLength).toEqual(2);
+    expect(selectorTextOne).toEqual(expectedSelectorTextOne);
+    expect(selectorTextTwo).toEqual(expectedSelectorTextTwo);
+  });
+});

--- a/libs/libs/styles.spec.js
+++ b/libs/libs/styles.spec.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var _styles = _interopRequireDefault(require("./styles.js"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+describe('addStyles function', function () {});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Atomic Jolt's front-end library code",
   "scripts": {
     "test": "jest --no-cache  --config package.json",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand --watch --config package.json",
     "jest_version": "which jest && jest --version",
     "build": "cross-env BABEL_ENV=production babel src --out-dir libs",
     "clean": "rimraf libs",

--- a/src/libs/styles.js
+++ b/src/libs/styles.js
@@ -1,7 +1,8 @@
-function getAddStyles() {
-  let styleEl = document.getElementById(id);
+export function getAddStyles() {
   const memo = {};
   const id = 'atomic-fuel-styles';
+
+  let styleEl = document.getElementById(id);
 
   return (styles) => {
     if (!styleEl) {

--- a/src/libs/styles.js
+++ b/src/libs/styles.js
@@ -1,4 +1,4 @@
-const function getAddStyles() {
+function getAddStyles() {
   let styleEl = document.getElementById(id);
   const memo = {};
   const id = 'atomic-fuel-styles';
@@ -13,11 +13,11 @@ const function getAddStyles() {
     const classes = styles.match(/.*[^{]/)[0];
 
     if (memo[classes] === undefined) {
-      styleEl.sheet.insertRule(styles, styleSheet.cssRules.length);
-    } else {
+      const styleSheet = styleEl.sheet;
+      styleSheet.insertRule(styles, styleSheet.cssRules.length);
       memo[classes] = 1;
     }
   };
 }
 
-export getAddStyles();
+export default getAddStyles();

--- a/src/libs/styles.js
+++ b/src/libs/styles.js
@@ -1,4 +1,4 @@
-export function getAddStyles() {
+function getAddStyles(selectorTextRegex = /[^{]*/) {
   const memo = {};
   const id = 'atomic-fuel-styles';
 
@@ -11,7 +11,12 @@ export function getAddStyles() {
       document.head.appendChild(styleEl);
     }
 
-    const classes = styles.match(/.*[^{]/)[0];
+    /*
+     * The RegEx below extracts the selectorText from the styles
+     * string. For example running this regex on the styles string
+     * ".myClass > h1 .myclassTwo {...}" would yield ".myClass > h1 .myclassTwo"
+     */
+    const classes = styles.match(selectorTextRegex)[0].trim();
 
     if (memo[classes] === undefined) {
       const styleSheet = styleEl.sheet;

--- a/src/libs/styles.js
+++ b/src/libs/styles.js
@@ -1,11 +1,23 @@
-export default function addStyles(styles) {
-  const id = 'atomic-fuel-styles';
+const function getAddStyles() {
   let styleEl = document.getElementById(id);
-  if (!styleEl) {
-    styleEl = document.createElement('style');
-    styleEl.id = id;
-    document.head.appendChild(styleEl);
-  }
-  const styleSheet = styleEl.sheet;
-  styleSheet.insertRule(styles, styleSheet.cssRules.length);
+  const memo = {};
+  const id = 'atomic-fuel-styles';
+
+  return (styles) => {
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = id;
+      document.head.appendChild(styleEl);
+    }
+
+    const classes = styles.match(/.*[^{]/)[0];
+
+    if (memo[classes] === undefined) {
+      styleEl.sheet.insertRule(styles, styleSheet.cssRules.length);
+    } else {
+      memo[classes] = 1;
+    }
+  };
 }
+
+export getAddStyles();

--- a/src/libs/styles.spec.js
+++ b/src/libs/styles.spec.js
@@ -1,0 +1,52 @@
+import addStyles from './styles.js';
+
+describe('addStyles function', () => {
+  it('Should only add one class rule to the style element when invoked repetitively', () => {
+    for (let i = 0; i < 5; i += 1) {
+      addStyles(`.error-banner__content {
+        color: #fff;
+        font-family: 'montserratregular';
+        font-weight: normal;
+        font-size: 1.4rem;
+      }`);
+    }
+
+    const styleEl = document.getElementById('atomic-fuel-styles');
+    const stylesheet = styleEl.sheet;
+    const rulesLength = stylesheet.cssRules.length;
+    expect(rulesLength).toEqual(1);
+  });
+
+  it('Should not insert repetitive selectorText to the style element', () => {
+    const expectedSelectorTextOne = '.error-banner__content';
+    const expectedSelectorTextTwo = '.atomicjolt-loading-animation svg polygon, .atomicjolt-loading-animation svg polyline';
+
+    for (let i = 0; i < 5; i += 1) {
+      addStyles(`${expectedSelectorTextOne} {
+        color: #fff;
+        font-family: 'montserratregular';
+        font-weight: normal;
+        font-size: 1.4rem;
+      }`);
+
+      addStyles(`${expectedSelectorTextTwo}{
+        fill: none;
+        stroke: #424;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 8px;
+      }`);
+    }
+
+    const styleEl = document.getElementById('atomic-fuel-styles');
+    const stylesheet = styleEl.sheet;
+    const rulesLength = stylesheet.cssRules.length;
+
+    const selectorTextOne = stylesheet.cssRules[0].selectorText;
+    const selectorTextTwo = stylesheet.cssRules[1].selectorText;
+
+    expect(rulesLength).toEqual(2);
+    expect(selectorTextOne).toEqual(expectedSelectorTextOne);
+    expect(selectorTextTwo).toEqual(expectedSelectorTextTwo);
+  });
+});


### PR DESCRIPTION
- AddStyles now memoizes cssRules so they aren't added repetitively 
- It only looks up the style element once and encloses its reference
- A testing suite was added for the AddStyle function
- Chrome DevTools can now be ran by executing: `yarn test:debug`
- Testing instructions were added to the README